### PR TITLE
Fix kristwallet

### DIFF
--- a/default/kristwallet
+++ b/default/kristwallet
@@ -1,6 +1,6 @@
 {
 	title = "Kristwallet",
-	url = "http://pastebin.com/raw/Yv0fChz5",
+	url = "http://pastebin.com/raw/iy2shdTw",
 	creator = "3d6",
 	description = "A wallet program for the crypto-currency Krist. Used to manage transactions and domains.",
 	catagory = 1,


### PR DESCRIPTION
The previous installer would just download a 404 Not Found page. Tested on Opus OS.